### PR TITLE
Fix duplicate ChatGPT call in DM handler

### DIFF
--- a/app.js
+++ b/app.js
@@ -67,10 +67,7 @@ async function handleMessage(message) {
   } else {
     // send a follow-up message with the stored parentMessageId
     const parentId = userParentMessageIds.get(userId);
-    openai_api.sendMessage(message.text, {
-      parentMessageId: parentId
-    }),
-    response = await openai_api.sendMessage(message.text, {parentMessageId: parentId});
+    response = await openai_api.sendMessage(message.text, { parentMessageId: parentId });
     // Reset the parent message id to the current message
     userParentMessageIds.set(userId, response.id);
   }


### PR DESCRIPTION
## Summary
- remove extra sendMessage call when handling replies

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68698223d23883248cc42060754693a6