### PR TITLE
Add /askgpt slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,12 @@ npm run start
 ```
 
 ### 4. Test
-Go to the installed workspace and type **help** in a DM to your new bot. 
+Go to the installed workspace and type **help** in a DM to your new bot.
+You can also use the new `/askgpt` slash command in any channel:
+
+```text
+/askgpt what is the weather today?
+```
 
 ### 5. Deploy to production
 You'll need a Linux server, container, or application platform that supports nodejs to keep the bot running. Slack has a tutorial for getting an app running on the Glitch platform: https://api.slack.com/tutorials/hello-world-bolt

--- a/app.js
+++ b/app.js
@@ -233,6 +233,9 @@ async function handleMessage(message) {
         'tiktok     - Wake up in the morning feeling like P Diddy',
         'rickroll   - Never gonna give you up, never gonna let you down.',
         '',
+        '# Slash command:',
+        '/askgpt <question> - Ask ChatGPT and get an ephemeral reply',
+        '',
         `# Address the bot directly with @${process.env.SLACK_BOT_USER_NAME} syntax:`,
         `@${process.env.SLACK_BOT_USER_NAME} the rules - Explains Asimov's laws of robotics`,
         `@${process.env.SLACK_BOT_USER_NAME} dad joke  - Provides a random dad joke`,
@@ -286,6 +289,13 @@ async function handleMessage(message) {
     // Fall back to ChatGPT if nothing above matches
     const responseText = await handleMessage(message);
     await say(responseText);
+  });
+
+  // Slash command to query ChatGPT directly
+  app.command('/askgpt', async ({ command, ack, respond }) => {
+    await ack();
+    const responseText = await handleMessage({ text: command.text, user: command.user_id });
+    await respond({ text: responseText, response_type: 'ephemeral' });
   });
 
   // Start the app

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -8,6 +8,11 @@ features:
   bot_user:
     display_name: Eve
     always_online: true
+  slash_commands:
+    - command: /askgpt
+      description: Ask ChatGPT a question
+      usage_hint: "/askgpt <question>"
+      should_escape: false
 oauth_config:
   scopes:
     bot:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eve-bolt-js-slack-chatbot",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Eve - a BoltJS powered Slack Chatbot",
   "main": "app.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- add `/askgpt` slash command implementation
- mention new slash command in help message
- document `/askgpt` in README
- describe slash command in manifest
- bump version to 2.1.0

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68698402d880832498ed1338af502117