### PR TITLE
Add DALL-E image generation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,11 @@ You can also use the new `/askgpt` slash command in any channel:
 /askgpt what is the weather today?
 ```
 
+You can also generate images with the `/image` command:
+
+```text
+/image a cat riding a skateboard
+```
+
 ### 5. Deploy to production
 You'll need a Linux server, container, or application platform that supports nodejs to keep the bot running. Slack has a tutorial for getting an app running on the Glitch platform: https://api.slack.com/tutorials/hello-world-bolt

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -13,6 +13,10 @@ features:
       description: Ask ChatGPT a question
       usage_hint: "/askgpt <question>"
       should_escape: false
+    - command: /image
+      description: Generate an image with DALL·E
+      usage_hint: "/image <prompt>"
+      should_escape: false
 oauth_config:
   scopes:
     bot:


### PR DESCRIPTION
## Summary
- implement `generateImage` helper to call OpenAI's DALL·E API
- handle `@botname image <prompt>` messages
- add `/image` slash command
- document new command
- expose `/image` in the Slack manifest

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686986fcedf48324bab2a4e1cb030903