### PR TITLE
Fix npm test and add basic tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "node app.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "license": "MIT",
   "dependencies": {

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { promises as fs } from 'fs';
+
+async function readPackage() {
+  const content = await fs.readFile('./package.json', 'utf8');
+  return JSON.parse(content);
+}
+
+test('package.json has a name property', async () => {
+  const pkg = await readPackage();
+  assert.ok(pkg.name, 'Expected package name to be defined');
+});
+
+test('package.json defines a start script', async () => {
+  const pkg = await readPackage();
+  assert.ok(pkg.scripts && pkg.scripts.start, 'Expected start script to be defined');
+});


### PR DESCRIPTION
## Summary
- enable Node's native test runner
- add a simple test that validates fields in `package.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686987b6c2e08324be3acabf3d24c498